### PR TITLE
Add basic metrics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,5 @@ repos:
           - pyresample
           - lightning
           - torch
+          - jaxtyping
+          - scikit-image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ dependencies = [
     "typer",
     "lightning",
     "torch",
-    "skimage",
+    "scikit-image",
+    "jaxtyping",
 ]
 [project.optional-dependencies]
 dev = [
@@ -65,6 +66,7 @@ filterwarnings = [
   "error",
   "ignore:pkg_resources:DeprecationWarning",                                        # lightning
   "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning",  # lightning
+  "ignore:ast.Str is deprecated:DeprecationWarning",             # jaxtyping
 ]
 log_cli_level = "INFO"
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "typer",
     "lightning",
     "torch",
+    "skimage",
 ]
 [project.optional-dependencies]
 dev = [

--- a/src/cloudcasting/__init__.py
+++ b/src/cloudcasting/__init__.py
@@ -6,7 +6,18 @@ from __future__ import annotations
 
 from importlib.metadata import version
 
+from jaxtyping import install_import_hook
+
+# Any module imported inside this `with` block, whose
+# name begins with the specified string, will
+# automatically have both `@jaxtyped` and the
+# typechecker applied to all of their functions and
+# dataclasses, meaning that they will be type-checked
+# (and therefore shape-checked via jaxtyping) at runtime.
+with install_import_hook("cloudcasting", "typeguard.typechecked"):
+    from cloudcasting import metrics
+
 from cloudcasting import cli, dataset, download
 
-__all__ = ("__version__", "download", "cli", "dataset")
+__all__ = ("__version__", "download", "cli", "dataset", "metrics")
 __version__ = version(__name__)

--- a/src/cloudcasting/metrics.py
+++ b/src/cloudcasting/metrics.py
@@ -1,16 +1,12 @@
 """Functions used to calculate common metrics on model outputs"""
-
-from collections.abc import Callable
-
 import numpy as np
 from numpy.typing import NDArray
-
 from skimage.metrics import structural_similarity
 
 
-def _check_input_and_targets(input: NDArray[np.float32], target: NDArray[np.float32]):
+def _check_input_and_targets(input: NDArray[np.float32], target: NDArray[np.float32]) -> None:
     """Perform a series of checks on the inputs and targets for validity
-    
+
     Args:
         input: Input array of shape [(batch), channels, time, height, width]
         target: target array of shape [(batch), channels, time, height, width]
@@ -19,9 +15,11 @@ def _check_input_and_targets(input: NDArray[np.float32], target: NDArray[np.floa
     ndims = len(input.shape)
 
     if ndims not in [4, 5]:
-        raise ValueError(f"Input expected to have 4 or 5 dimensions - found {ndims}")
+        error_msg = f"Input expected to have 4 or 5 dimensions - found {ndims}"
+        raise ValueError(error_msg)
     if input.shape != target.shape:
-        raise ValueError(f"Input {input.shape} and target {target.shape} must have the same shape")
+        error_msg = f"Input {input.shape} and target {target.shape} must have the same shape"
+        raise ValueError(error_msg)
 
 
 def calc_mae(input: NDArray[np.float32], target: NDArray[np.float32]) -> NDArray[np.float32]:
@@ -63,10 +61,8 @@ def calc_mse(input: NDArray[np.float32], target: NDArray[np.float32]) -> NDArray
 
 
 def _calc_ssim_sample(
-        input: NDArray[np.float32], 
-        target: NDArray[np.float32], 
-        win_size: int | None = None
-    ) -> NDArray[np.float32]:
+    input: NDArray[np.float32], target: NDArray[np.float32], win_size: int | None = None
+) -> NDArray[np.float32]:
     """Calculate the structual similarity between non-batched image sequences
 
     The result is the mean along all dimensions except the time dimension
@@ -91,11 +87,10 @@ def _calc_ssim_sample(
 
         ssim_seq.append(np.nanmean(ssim_array))
 
-    ssim = np.stack(ssim_seq, axis=0)
-    return ssim
+    return np.stack(ssim_seq, axis=0)
 
 
-def _check_input_target_ranges(input: NDArray[np.float32], target: NDArray[np.float32]):
+def _check_input_target_ranges(input: NDArray[np.float32], target: NDArray[np.float32]) -> None:
     """Check if input and target are in the expected range of 0-1"""
     input_max = input.max()
     input_min = input.min()
@@ -112,10 +107,8 @@ def _check_input_target_ranges(input: NDArray[np.float32], target: NDArray[np.fl
 
 
 def calc_ssim(
-        input: NDArray[np.float32], 
-        target: NDArray[np.float32], 
-        win_size: int | None = None
-    ) -> NDArray[np.float32]:
+    input: NDArray[np.float32], target: NDArray[np.float32], win_size: int | None = None
+) -> NDArray[np.float32]:
     """Calculate the structual similarity between batched or non-batched image sequences
 
     The result is the mean along all dimensions except the time dimension
@@ -136,8 +129,6 @@ def calc_ssim(
         ssim_samples = []
         for i_b in range(input.shape[0]):
             ssim_samples.append(_calc_ssim_sample(input[i_b], target[i_b], win_size=win_size))
-        ssim = np.stack(ssim_samples, axis=0).mean(axis=0)
+        return np.stack(ssim_samples, axis=0).mean(axis=0)
     else:
-        ssim = _calc_ssim_sample(input, target, win_size=win_size)
-
-    return ssim
+        return _calc_ssim_sample(input, target, win_size=win_size)

--- a/src/cloudcasting/metrics.py
+++ b/src/cloudcasting/metrics.py
@@ -68,8 +68,8 @@ def _calc_ssim_sample(
     The result is the mean along all dimensions except the time dimension
 
     Args:
-        input: Input array of shape [(batch), channels, time, height, width]
-        target: target array of shape [(batch), channels, time, height, width]
+        input: Input array of shape [channels, time, height, width]
+        target: target array of shape [channels, time, height, width]
         win_size: The side-length of the sliding window used in comparison. Must be an odd value.
     """
 

--- a/src/cloudcasting/metrics.py
+++ b/src/cloudcasting/metrics.py
@@ -1,0 +1,143 @@
+"""Functions used to calculate common metrics on model outputs"""
+
+from collections.abc import Callable
+
+import numpy as np
+from numpy.typing import NDArray
+
+from skimage.metrics import structural_similarity
+
+
+def _check_input_and_targets(input: NDArray[np.float32], target: NDArray[np.float32]):
+    """Perform a series of checks on the inputs and targets for validity
+    
+    Args:
+        input: Input array of shape [(batch), channels, time, height, width]
+        target: target array of shape [(batch), channels, time, height, width]
+    """
+
+    ndims = len(input.shape)
+
+    if ndims not in [4, 5]:
+        raise ValueError(f"Input expected to have 4 or 5 dimensions - found {ndims}")
+    if input.shape != target.shape:
+        raise ValueError(f"Input {input.shape} and target {target.shape} must have the same shape")
+
+
+def calc_mae(input: NDArray[np.float32], target: NDArray[np.float32]) -> NDArray[np.float32]:
+    """Calculate the mean absolute error between between batched or non-batched image sequences
+
+    The result is the mean along all dimensions except the time dimension
+
+    Args:
+        input: Input array of shape [(batch), channels, time, height, width]
+        target: target array of shape [(batch), channels, time, height, width]
+    """
+    _check_input_and_targets(input, target)
+
+    absolute_error = np.abs(input - target)
+
+    if len(input.shape) == 5:
+        return np.nanmean(absolute_error, axis=(0, 1, 3, 4))
+    else:
+        return np.nanmean(absolute_error, axis=(0, 2, 3))
+
+
+def calc_mse(input: NDArray[np.float32], target: NDArray[np.float32]) -> NDArray[np.float32]:
+    """Calculate the mean square error between between batched or non-batched image sequences
+
+    The result is the mean along all dimensions except the time dimension
+
+    Args:
+        input: Input array of shape [(batch), channels, time, height, width]
+        target: target array of shape [(batch), channels, time, height, width]
+    """
+    _check_input_and_targets(input, target)
+
+    square_error = (input - target) ** 2
+
+    if len(input.shape) == 5:
+        return np.nanmean(square_error, axis=(0, 1, 3, 4))
+    else:
+        return np.nanmean(square_error, axis=(0, 2, 3))
+
+
+def _calc_ssim_sample(
+        input: NDArray[np.float32], 
+        target: NDArray[np.float32], 
+        win_size: int | None = None
+    ) -> NDArray[np.float32]:
+    """Calculate the structual similarity between non-batched image sequences
+
+    The result is the mean along all dimensions except the time dimension
+
+    Args:
+        input: Input array of shape [(batch), channels, time, height, width]
+        target: target array of shape [(batch), channels, time, height, width]
+        win_size: The side-length of the sliding window used in comparison. Must be an odd value.
+    """
+
+    # Loop through the time index and compute SSIM on image pairs
+    ssim_seq = []
+    for i_t in range(input.shape[1]):
+        _, ssim_array = structural_similarity(
+            input[:, i_t],
+            target[:, i_t],
+            data_range=1,
+            channel_axis=0,
+            full=True,
+            win_size=win_size,
+        )
+
+        ssim_seq.append(np.nanmean(ssim_array))
+
+    ssim = np.stack(ssim_seq, axis=0)
+    return ssim
+
+
+def _check_input_target_ranges(input: NDArray[np.float32], target: NDArray[np.float32]):
+    """Check if input and target are in the expected range of 0-1"""
+    input_max = input.max()
+    input_min = input.min()
+    target_max = target.max()
+    target_min = target.min()
+
+    if (input_min < 0) | (input_max > 1) | (target_min < 0) | (target_max > 1):
+        error_msg = (
+            "Input and target arrays must be in the range 0-1. "
+            f"Input range: {input_min}-{input_max}. "
+            f"Target range: {target_min}-{target_max}"
+        )
+        raise ValueError(error_msg)
+
+
+def calc_ssim(
+        input: NDArray[np.float32], 
+        target: NDArray[np.float32], 
+        win_size: int | None = None
+    ) -> NDArray[np.float32]:
+    """Calculate the structual similarity between batched or non-batched image sequences
+
+    The result is the mean along all dimensions except the time dimension
+
+    Args:
+        input: Input array of shape [(batch), channels, time, height, width]
+        target: target array of shape [(batch), channels, time, height, width]
+        win_size: The side-length of the sliding window used in comparison. Must be an odd value.
+    """
+
+    _check_input_and_targets(input, target)
+
+    # This function assumes the data will be in the range 0-1 and will give invalid results if not
+    _check_input_target_ranges(input, target)
+
+    if len(input.shape) == 5:
+        # If the input is batched samples, loop through the samples
+        ssim_samples = []
+        for i_b in range(input.shape[0]):
+            ssim_samples.append(_calc_ssim_sample(input[i_b], target[i_b], win_size=win_size))
+        ssim = np.stack(ssim_samples, axis=0).mean(axis=0)
+    else:
+        ssim = _calc_ssim_sample(input, target, win_size=win_size)
+
+    return ssim

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,87 +1,86 @@
-import pytest
 import numpy as np
+import pytest
+
 from cloudcasting.metrics import calc_mae, calc_mse, calc_ssim
 
 
-@pytest.fixture
+@pytest.fixture()
 def zeros_sample():
     # shape: channels, time, height, width
     return np.zeros((2, 6, 24, 24), dtype=np.float32)
 
-@pytest.fixture
+
+@pytest.fixture()
 def ones_sample():
     # shape: channels, time, height, width
     return np.ones((2, 6, 24, 24), dtype=np.float32)
 
-@pytest.fixture
+
+@pytest.fixture()
 def zeros_missing_sample():
-     # shape: channels, time, height, width
+    # shape: channels, time, height, width
     x = np.zeros((2, 6, 24, 24), dtype=np.float32)
     x[0, 0, 0, 0] = np.nan
     return x
 
-@pytest.fixture
+
+@pytest.fixture()
 def zeros_batch():
     # shape: batch, channels, time, height, width
     return np.zeros((4, 2, 6, 24, 24), dtype=np.float32)
 
-@pytest.fixture
+
+@pytest.fixture()
 def ones_batch():
     # shape: batch, channels, time, height, width
     return np.ones((4, 2, 6, 24, 24), dtype=np.float32)
 
 
-
 def test_calc_mae_sample(zeros_sample, ones_sample, zeros_missing_sample):
-
     result = calc_mae(zeros_sample, zeros_sample)
-    assert (result==0).all()
+    assert (result == 0).all()
 
     result = calc_mae(ones_sample, zeros_sample)
-    assert (result==1).all()
+    assert (result == 1).all()
 
     result = calc_mae(zeros_sample, zeros_missing_sample)
-    assert (result==0).all()
+    assert (result == 0).all()
 
 
 def test_calc_mae_batch(zeros_batch, ones_batch):
-
     result = calc_mae(zeros_batch, zeros_batch)
-    assert (result==0).all()
+    assert (result == 0).all()
 
     result = calc_mae(ones_batch, zeros_batch)
-    assert (result==1).all()
+    assert (result == 1).all()
 
 
 def test_calc_mse_sample(zeros_sample, ones_sample, zeros_missing_sample):
-
     result = calc_mse(zeros_sample, zeros_sample)
-    assert (result==0).all()
+    assert (result == 0).all()
 
     result = calc_mse(ones_sample, zeros_sample)
-    assert (result==1).all()
+    assert (result == 1).all()
 
-    result = calc_mse(ones_sample*2, zeros_sample)
-    assert (result==4).all()
+    result = calc_mse(ones_sample * 2, zeros_sample)
+    assert (result == 4).all()
 
     result = calc_mse(zeros_sample, zeros_missing_sample)
-    assert (result==0).all()
+    assert (result == 0).all()
 
 
 def test_calc_mse_batch(zeros_batch, ones_batch):
-
     result = calc_mse(zeros_batch, zeros_batch)
-    assert (result==0).all()
+    assert (result == 0).all()
 
     result = calc_mse(ones_batch, zeros_batch)
-    assert (result==1).all()
+    assert (result == 1).all()
 
-    result = calc_mse(ones_batch*2, zeros_batch)
-    assert (result==4).all()
+    result = calc_mse(ones_batch * 2, zeros_batch)
+    assert (result == 4).all()
 
 
 def test_calc_ssim_sample(zeros_sample, ones_sample, zeros_missing_sample):
-
     result = calc_ssim(zeros_sample, zeros_sample)
     np.testing.assert_almost_equal(result, 1, decimal=4)
 
@@ -96,7 +95,6 @@ def test_calc_ssim_sample(zeros_sample, ones_sample, zeros_missing_sample):
 
 
 def test_calc_ssim_batch(zeros_batch, ones_batch):
-
     result = calc_ssim(zeros_batch, zeros_batch)
     np.testing.assert_almost_equal(result, 1, decimal=4)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,7 +1,16 @@
+import jaxtyping
 import numpy as np
 import pytest
+import torch
 
-from cloudcasting.metrics import calc_mae, calc_mse, calc_ssim
+from cloudcasting.metrics import (
+    mae_batch,
+    mae_single,
+    mse_batch,
+    mse_single,
+    ssim_batch,
+    ssim_single,
+)
 
 
 @pytest.fixture()
@@ -37,69 +46,137 @@ def ones_batch():
 
 
 def test_calc_mae_sample(zeros_sample, ones_sample, zeros_missing_sample):
-    result = calc_mae(zeros_sample, zeros_sample)
+    result = mae_single(zeros_sample, zeros_sample)
     assert (result == 0).all()
 
-    result = calc_mae(ones_sample, zeros_sample)
+    result = mae_single(ones_sample, zeros_sample)
     assert (result == 1).all()
 
-    result = calc_mae(zeros_sample, zeros_missing_sample)
+    result = mae_single(zeros_sample, zeros_missing_sample)
     assert (result == 0).all()
 
 
 def test_calc_mae_batch(zeros_batch, ones_batch):
-    result = calc_mae(zeros_batch, zeros_batch)
+    result = mae_batch(zeros_batch, zeros_batch)
     assert (result == 0).all()
 
-    result = calc_mae(ones_batch, zeros_batch)
+    result = mae_batch(ones_batch, zeros_batch)
     assert (result == 1).all()
 
 
 def test_calc_mse_sample(zeros_sample, ones_sample, zeros_missing_sample):
-    result = calc_mse(zeros_sample, zeros_sample)
+    result = mse_single(zeros_sample, zeros_sample)
     assert (result == 0).all()
 
-    result = calc_mse(ones_sample, zeros_sample)
+    result = mse_single(ones_sample, zeros_sample)
     assert (result == 1).all()
 
-    result = calc_mse(ones_sample * 2, zeros_sample)
+    result = mse_single(ones_sample * 2, zeros_sample)
     assert (result == 4).all()
 
-    result = calc_mse(zeros_sample, zeros_missing_sample)
+    result = mse_single(zeros_sample, zeros_missing_sample)
     assert (result == 0).all()
 
 
 def test_calc_mse_batch(zeros_batch, ones_batch):
-    result = calc_mse(zeros_batch, zeros_batch)
+    result = mse_batch(zeros_batch, zeros_batch)
     assert (result == 0).all()
 
-    result = calc_mse(ones_batch, zeros_batch)
+    result = mse_batch(ones_batch, zeros_batch)
     assert (result == 1).all()
 
-    result = calc_mse(ones_batch * 2, zeros_batch)
+    result = mse_batch(ones_batch * 2, zeros_batch)
     assert (result == 4).all()
 
 
 def test_calc_ssim_sample(zeros_sample, ones_sample, zeros_missing_sample):
-    result = calc_ssim(zeros_sample, zeros_sample)
+    result = ssim_single(zeros_sample, zeros_sample)
     np.testing.assert_almost_equal(result, 1, decimal=4)
 
-    result = calc_ssim(ones_sample, ones_sample)
+    result = ssim_single(ones_sample, ones_sample)
     np.testing.assert_almost_equal(result, 1, decimal=4)
 
-    result = calc_ssim(zeros_sample, ones_sample)
+    result = ssim_single(zeros_sample, ones_sample)
     np.testing.assert_almost_equal(result, 0, decimal=4)
 
-    result = calc_ssim(zeros_sample, zeros_missing_sample)
+    result = ssim_single(zeros_sample, zeros_missing_sample)
     np.testing.assert_almost_equal(result, 1, decimal=4)
 
 
 def test_calc_ssim_batch(zeros_batch, ones_batch):
-    result = calc_ssim(zeros_batch, zeros_batch)
+    result = ssim_batch(zeros_batch, zeros_batch)
     np.testing.assert_almost_equal(result, 1, decimal=4)
 
-    result = calc_ssim(ones_batch, ones_batch)
+    result = ssim_batch(ones_batch, ones_batch)
     np.testing.assert_almost_equal(result, 1, decimal=4)
 
-    result = calc_ssim(zeros_batch, ones_batch)
+    result = ssim_batch(zeros_batch, ones_batch)
     np.testing.assert_almost_equal(result, 0, decimal=4)
+
+
+def test_wrong_shapes(zeros_sample, ones_batch):
+    with pytest.raises(jaxtyping.TypeCheckError):
+        mae_single(zeros_sample, ones_batch)
+
+    with pytest.raises(jaxtyping.TypeCheckError):
+        mae_batch(zeros_sample, ones_batch)
+
+    with pytest.raises(jaxtyping.TypeCheckError):
+        mse_single(zeros_sample, ones_batch)
+
+    with pytest.raises(jaxtyping.TypeCheckError):
+        mse_batch(zeros_sample, ones_batch)
+
+    with pytest.raises(jaxtyping.TypeCheckError):
+        ssim_single(zeros_sample, ones_batch)
+
+    with pytest.raises(jaxtyping.TypeCheckError):
+        ssim_batch(zeros_sample, ones_batch)
+
+
+def test_wrong_shapes_torch(zeros_sample, ones_batch):
+    with pytest.raises(jaxtyping.TypeCheckError):
+        mae_single(torch.Tensor(zeros_sample), torch.Tensor(ones_batch))
+
+    with pytest.raises(jaxtyping.TypeCheckError):
+        mae_batch(torch.Tensor(zeros_sample), torch.Tensor(ones_batch))
+
+    with pytest.raises(jaxtyping.TypeCheckError):
+        mse_single(torch.Tensor(zeros_sample), torch.Tensor(ones_batch))
+
+    with pytest.raises(jaxtyping.TypeCheckError):
+        mse_batch(torch.Tensor(zeros_sample), torch.Tensor(ones_batch))
+
+    with pytest.raises(jaxtyping.TypeCheckError):
+        ssim_single(torch.Tensor(zeros_sample), torch.Tensor(ones_batch))
+
+    with pytest.raises(jaxtyping.TypeCheckError):
+        ssim_batch(torch.Tensor(zeros_sample), torch.Tensor(ones_batch))
+
+
+def test_input_ranges_ssim_single(zeros_sample, ones_sample):
+    with pytest.raises(ValueError, match="Input and target must be in 0-1 range"):
+        ssim_single(zeros_sample - 1, ones_sample)
+
+    with pytest.raises(ValueError, match="Input and target must be in 0-1 range"):
+        ssim_single(ones_sample, zeros_sample - 1)
+
+    with pytest.raises(ValueError, match="Input and target must be in 0-1 range"):
+        ssim_single(zeros_sample, ones_sample + 1)
+
+    with pytest.raises(ValueError, match="Input and target must be in 0-1 range"):
+        ssim_single(ones_sample + 1, zeros_sample)
+
+
+def test_input_ranges_ssim_batch(zeros_batch, ones_batch):
+    with pytest.raises(ValueError, match="Input and target must be in 0-1 range"):
+        ssim_batch(zeros_batch - 1, ones_batch)
+
+    with pytest.raises(ValueError, match="Input and target must be in 0-1 range"):
+        ssim_batch(ones_batch, zeros_batch - 1)
+
+    with pytest.raises(ValueError, match="Input and target must be in 0-1 range"):
+        ssim_batch(zeros_batch, ones_batch + 1)
+
+    with pytest.raises(ValueError, match="Input and target must be in 0-1 range"):
+        ssim_batch(ones_batch + 1, zeros_batch)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,107 @@
+import pytest
+import numpy as np
+from cloudcasting.metrics import calc_mae, calc_mse, calc_ssim
+
+
+@pytest.fixture
+def zeros_sample():
+    # shape: channels, time, height, width
+    return np.zeros((2, 6, 24, 24), dtype=np.float32)
+
+@pytest.fixture
+def ones_sample():
+    # shape: channels, time, height, width
+    return np.ones((2, 6, 24, 24), dtype=np.float32)
+
+@pytest.fixture
+def zeros_missing_sample():
+     # shape: channels, time, height, width
+    x = np.zeros((2, 6, 24, 24), dtype=np.float32)
+    x[0, 0, 0, 0] = np.nan
+    return x
+
+@pytest.fixture
+def zeros_batch():
+    # shape: batch, channels, time, height, width
+    return np.zeros((4, 2, 6, 24, 24), dtype=np.float32)
+
+@pytest.fixture
+def ones_batch():
+    # shape: batch, channels, time, height, width
+    return np.ones((4, 2, 6, 24, 24), dtype=np.float32)
+
+
+
+def test_calc_mae_sample(zeros_sample, ones_sample, zeros_missing_sample):
+
+    result = calc_mae(zeros_sample, zeros_sample)
+    assert (result==0).all()
+
+    result = calc_mae(ones_sample, zeros_sample)
+    assert (result==1).all()
+
+    result = calc_mae(zeros_sample, zeros_missing_sample)
+    assert (result==0).all()
+
+
+def test_calc_mae_batch(zeros_batch, ones_batch):
+
+    result = calc_mae(zeros_batch, zeros_batch)
+    assert (result==0).all()
+
+    result = calc_mae(ones_batch, zeros_batch)
+    assert (result==1).all()
+
+
+def test_calc_mse_sample(zeros_sample, ones_sample, zeros_missing_sample):
+
+    result = calc_mse(zeros_sample, zeros_sample)
+    assert (result==0).all()
+
+    result = calc_mse(ones_sample, zeros_sample)
+    assert (result==1).all()
+
+    result = calc_mse(ones_sample*2, zeros_sample)
+    assert (result==4).all()
+
+    result = calc_mse(zeros_sample, zeros_missing_sample)
+    assert (result==0).all()
+
+
+def test_calc_mse_batch(zeros_batch, ones_batch):
+
+    result = calc_mse(zeros_batch, zeros_batch)
+    assert (result==0).all()
+
+    result = calc_mse(ones_batch, zeros_batch)
+    assert (result==1).all()
+
+    result = calc_mse(ones_batch*2, zeros_batch)
+    assert (result==4).all()
+
+
+def test_calc_ssim_sample(zeros_sample, ones_sample, zeros_missing_sample):
+
+    result = calc_ssim(zeros_sample, zeros_sample)
+    np.testing.assert_almost_equal(result, 1, decimal=4)
+
+    result = calc_ssim(ones_sample, ones_sample)
+    np.testing.assert_almost_equal(result, 1, decimal=4)
+
+    result = calc_ssim(zeros_sample, ones_sample)
+    np.testing.assert_almost_equal(result, 0, decimal=4)
+
+    result = calc_ssim(zeros_sample, zeros_missing_sample)
+    np.testing.assert_almost_equal(result, 1, decimal=4)
+
+
+def test_calc_ssim_batch(zeros_batch, ones_batch):
+
+    result = calc_ssim(zeros_batch, zeros_batch)
+    np.testing.assert_almost_equal(result, 1, decimal=4)
+
+    result = calc_ssim(ones_batch, ones_batch)
+    np.testing.assert_almost_equal(result, 1, decimal=4)
+
+    result = calc_ssim(zeros_batch, ones_batch)
+    np.testing.assert_almost_equal(result, 0, decimal=4)


### PR DESCRIPTION
Add functions for basic metrics. These include:

- Mean squared error
- Mean absolute error
- Structural similarity index measure

We may wish to include more metrics later, but these seem to be the core set that a lot of image-to-image comparisons use

Here are some extra considerations

- The targets will include NaN values where the values are missing. We ignore these pixels in calculating the metrics.
- The current SSIM calculation made using the function in skimage is slow do to recursive loops over batch and time dimensions here, and over the channel dimension inside the skimage function. We may wish to replace this later with a more efficient version